### PR TITLE
[FEAT] 강의 출석부 조회 기능 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
           <Route path="/qnalist/:num" element={<QnADetailPage/>}/>
           <Route path="/curriculum" element={<CurriculumPage/>}/>
           <Route path="/account" element={<AccountPage/>}/>
-          <Route path="/attendancemanagement" element={<AttendanceManagementPage/>}/>
+          <Route path="/instructor/lectures/:lectureId/attendance" element={<AttendanceManagementPage/>}/>
         </Routes>
       </Router>
   );

--- a/src/pages/attendance/AttendanceManagementPage.jsx
+++ b/src/pages/attendance/AttendanceManagementPage.jsx
@@ -3,43 +3,31 @@ import AttendanceStatusSection from './AttendanceStatusSection';
 import Sidebar from "../../components/layout/Sidebar.jsx";
 import TopBar from "../../components/layout/TopBar.jsx";
 import AttendanceTable from "./AttendanceTable.jsx";
+import { useParams } from "react-router-dom";
+import axios from "axios";
 
 /**
  * 출석부 관리를 위한 메인 페이지 컴포넌트
  * 출석 상태 변경, 저장 및 통계 기능 제공
  */
 const AttendanceManagementPage = () => {
-  // 초기 학생 데이터
-  const initialStudents = [
-    { no: 1, name: '김경환', status: '출석' },
-    { no: 2, name: '박은화', status: '출석' },
-    { no: 3, name: '박종호', status: '출석' },
-    { no: 4, name: '성기범', status: '출석' },
-    { no: 5, name: '신동진', status: '병가' },
-    { no: 6, name: '오승찬', status: '출석' },
-    { no: 7, name: '오찬근', status: '결석' },
-    { no: 8, name: '이한나', status: '출석' },
-    { no: 9, name: '임진희', status: '출석' },
-    { no: 10, name: '임혜린', status: '출석' },
-    { no: 11, name: '정진욱', status: '출석' },
-    { no: 12, name: '홍인표', status: '출석' },
-    { no: 13, name: '황신욱', status: '출석' },
-  ];
+  const { lectureId } = useParams();
 
   // 상태 관리
-  const [students, setStudents] = useState(initialStudents);
+  const [students, setStudents] = useState([]);
   const [modifiedStudents, setModifiedStudents] = useState(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState({ type: '', message: '' });
   const [stats, setStats] = useState({
-    total: initialStudents.length,
-    present: initialStudents.filter(s => s.status === '출석').length,
-    late: initialStudents.filter(s => s.status === '지각').length,
-    sick: initialStudents.filter(s => s.status === '병가').length,
-    absent: initialStudents.filter(s => s.status === '결석').length,
+    total: 0,
+    present: 0,
+    late: 0,
+    sick: 0,
+    absent: 0,
   });
+  const [currentDate, setCurrentDate] = useState(new Date().toISOString().split('T')[0]); // 오늘 날짜로 초기화
 
   // 토스트 메시지 처리
   useEffect(() => {
@@ -70,7 +58,7 @@ const AttendanceManagementPage = () => {
       total: studentList.length,
       present: studentList.filter(s => s.status === '출석').length,
       late: studentList.filter(s => s.status === '지각').length,
-      sick: studentList.filter(s => s.status === '병가').length,
+      sick: studentList.filter(s => s.status === '병결').length,
       absent: studentList.filter(s => s.status === '결석').length,
     });
   };
@@ -110,11 +98,52 @@ const AttendanceManagementPage = () => {
     }
   };
 
+  // 날짜 변경 핸들러
+  const handleDateChange = (e) => {
+    setCurrentDate(e.target.value);
+    fetchAttendances(e.target.value);
+  };
+
+  // API 호출 함수
+  const fetchAttendances = async (date) => {
+    try {
+      setIsLoading(true);
+      const token = localStorage.getItem("token");
+      const { data } = await axios.get(`http://localhost:8080/api/instructor/lectures/${lectureId}/attendances`, {
+        params: { date },
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const formattedData = data.map((item, index) => ({
+        no: index + 1,
+        name: item.name,
+        status: item.status
+      }));
+
+      setStudents(formattedData);
+      updateStats(formattedData);
+    } catch (error) {
+      setToastMessage({
+        type: 'error',
+        message: error.response?.data?.message || '출석 정보를 불러오는데 실패했습니다.'
+      });
+      setShowToast(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 컴포넌트 마운트 시 데이터 로드
+  useEffect(() => {
+    fetchAttendances(currentDate);
+  }, []);
+
   // 변경사항 초기화
-  const resetChanges = () => {
-    setStudents(initialStudents);
+  const resetChanges = async () => {
+    await fetchAttendances(currentDate); // 서버에서 다시 데이터를 불러옴
     setModifiedStudents(new Set());
-    updateStats(initialStudents);
     setShowUnsavedDialog(false);
   };
 
@@ -125,12 +154,23 @@ const AttendanceManagementPage = () => {
           <TopBar/>
           <div className="p-6 bg-gray-50 min-h-screen">
             <div className="max-w-7xl mx-auto space-y-6">
-              <AttendanceStatusSection stats={stats}/>
-              <AttendanceTable
-                  students={students}
-                  onStudentStatusChange={handleStudentStatusChange}
-              />
-
+              {isLoading ? (
+                  <div className="flex justify-center items-center h-64">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"/>
+                  </div>
+              ) : (
+                  <>
+                    <AttendanceStatusSection
+                        stats={stats}
+                        currentDate={currentDate}
+                        onDateChange={handleDateChange}
+                    />
+                    <AttendanceTable
+                        students={students}
+                        onStudentStatusChange={handleStudentStatusChange}
+                    />
+                  </>
+              )}
               {/* 토스트 메시지 */}
               {showToast && (
                   <div className={`fixed top-4 right-4 px-6 py-3 rounded-lg shadow-lg transform transition-all duration-300 

--- a/src/pages/attendance/AttendanceManagementPage.jsx
+++ b/src/pages/attendance/AttendanceManagementPage.jsx
@@ -108,6 +108,8 @@ const AttendanceManagementPage = () => {
   const fetchAttendances = async (date) => {
     try {
       setIsLoading(true);
+
+      // TODO: 전역 Axios 인스턴스 사용
       const token = localStorage.getItem("token");
       const { data } = await axios.get(`http://localhost:8080/api/instructor/lectures/${lectureId}/attendances`, {
         params: { date },

--- a/src/pages/attendance/AttendanceRow.jsx
+++ b/src/pages/attendance/AttendanceRow.jsx
@@ -7,7 +7,7 @@ const AttendanceRow = ({ student, onStatusChange }) => {
   const statuses = [
     { key: '출석', color: 'green', bgClass: 'bg-green-500', borderClass: 'border-green-500 hover:border-green-400' },
     { key: '지각', color: 'orange', bgClass: 'bg-orange-500', borderClass: 'border-orange-500 hover:border-orange-400' },
-    { key: '병가', color: 'gray', bgClass: 'bg-gray-500', borderClass: 'border-gray-500 hover:border-gray-400' },
+    { key: '병결', color: 'gray', bgClass: 'bg-gray-500', borderClass: 'border-gray-500 hover:border-gray-400' },
     { key: '결석', color: 'blue', bgClass: 'bg-blue-500', borderClass: 'border-blue-500 hover:border-blue-400' }
   ];
 
@@ -25,7 +25,7 @@ const AttendanceRow = ({ student, onStatusChange }) => {
       case '결석':
         className += 'bg-blue-50 text-blue-700';
         break;
-      case '병가':
+      case '병결':
         className += 'bg-gray-50 text-gray-700';
         break;
       case '지각':

--- a/src/pages/attendance/AttendanceStatusSection.jsx
+++ b/src/pages/attendance/AttendanceStatusSection.jsx
@@ -5,13 +5,19 @@ import StatCards from './StatCards';
 /**
  * 전체 출석 현황의 요약 통계를 표시하는 헤더 섹션 컴포넌트
  */
-const AttendanceStatusSection = ({ stats }) => {
+const AttendanceStatusSection = ({ stats, currentDate, onDateChange }) => {
   return (
       <div className="w-full bg-white rounded-3xl shadow-sm p-4">
         <div className="flex items-center justify-center px-2">
-          <div className="flex items-center gap-3 mr-4">
+          <div className="flex items-center gap-3">
             <ClipboardList className="w-6 h-6 text-green-500"/>
             <span className="text-lg font-medium">출석부</span>
+            <input
+                type="date"
+                className="ml-4 px-3 py-1 border rounded-lg text-sm text-gray-600"
+                value={currentDate}
+                onChange={onDateChange}
+            />
           </div>
           <StatCards stats={stats}/>
         </div>

--- a/src/pages/attendance/AttendanceTable.jsx
+++ b/src/pages/attendance/AttendanceTable.jsx
@@ -23,7 +23,7 @@ const AttendanceTable = ({ students, onStudentStatusChange }) => {
             <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">수강생 이름</th>
             <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">출석</th>
             <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">지각</th>
-            <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">병가</th>
+            <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">병결</th>
             <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">결석</th>
             <th className="py-3 px-4 text-center text-sm font-medium text-gray-600">상태</th>
           </tr>

--- a/src/pages/attendance/StatCards.jsx
+++ b/src/pages/attendance/StatCards.jsx
@@ -28,7 +28,7 @@ const StatCards = ({ stats }) => {
         />
         <StatCard
             icon={<Stethoscope className="w-6 h-6 text-gray-500"/>}
-            label="병가"
+            label="병결"
             count={stats.sick}
             bgColor="gray"
         />


### PR DESCRIPTION
## 관련 이슈
- Closes #35 

## 변경 사항
1. 출석 관리 페이지 URL 구조 개선
    - `/attendancemanagement` 경로를 `/instructor/lectures/:lectureId/attendance`로 변경
    - RESTful한 URL 구조 적용

2. 출석부 API 연동 
    - 날짜별 출석 데이터 조회 API 연동
    - 로딩 상태 UI 구현
    - 더미 데이터 제거

3. 출석부 기능 개선
    - 날짜 선택 기능 추가
    - '병가'를 '병결'로 용어 통일
    - TODO 주석 추가

## 스크린샷
|기능|스크린샷|
|---|---|
|출석 상태 컴포넌트|![image](https://github.com/user-attachments/assets/50b65248-1a01-4a05-b6c0-680e23061a69)|
|날짜 선택 화면|![image](https://github.com/user-attachments/assets/1d510aa2-0b55-4ba4-bfed-aa2c3d469e00)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 출석부 통계 현황이 즉시 반영되도록 구현했습니다.
- API 응답 에러 처리 및 토스트 메시지 추가했습니다.

## 추후 업무
- [ ] 출석 데이터 수정 API 연동