### PR TITLE
[FEAT] 수강생 출석 상태 변경 기능 연동 및 날짜 선택 UI 변경

### DIFF
--- a/src/pages/attendance/AttendanceStatusSection.jsx
+++ b/src/pages/attendance/AttendanceStatusSection.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { ClipboardList } from 'lucide-react';
 import StatCards from './StatCards';
+import DateNavigation from "./DateNavigation.jsx";
 
 /**
- * 전체 출석 현황의 요약 통계를 표시하는 헤더 섹션 컴포넌트
+ * 출석부 상단 섹션 컴포넌트
+ * 날짜 네비게이션과 출석 현황 통계를 표시
  */
 const AttendanceStatusSection = ({ stats, currentDate, onDateChange }) => {
   return (
-      <div className="w-full bg-white rounded-3xl shadow-sm p-4">
-        <div className="flex items-center justify-center px-2">
-          <div className="flex items-center gap-3">
-            <ClipboardList className="w-6 h-6 text-green-500"/>
-            <span className="text-lg font-medium">출석부</span>
-            <input
-                type="date"
-                className="ml-4 px-3 py-1 border rounded-lg text-sm text-gray-600"
-                value={currentDate}
-                onChange={onDateChange}
-            />
+      <div className="space-y-4">
+        <DateNavigation
+            currentDate={currentDate}
+            onDateChange={onDateChange}
+        />
+        <div className="w-full bg-white rounded-3xl shadow-sm p-4">
+          <div className="flex items-center justify-center px-2">
+            <div className="flex items-center gap-3 mr-4">
+              <ClipboardList className="w-6 h-6 text-green-500"/>
+              <span className="text-lg font-medium">출석률</span>
+            </div>
+            <StatCards stats={stats}/>
           </div>
-          <StatCards stats={stats}/>
         </div>
       </div>
   );

--- a/src/pages/attendance/DateNavigation.jsx
+++ b/src/pages/attendance/DateNavigation.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+/**
+ * 날짜 네비게이션 컴포넌트
+ * 이전/다음 날짜로 이동 기능 제공
+ * 오늘 날짜까지만 선택 가능하도록 제한
+ */
+const DateNavigation = ({ currentDate, onDateChange }) => {
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    return `${year}년 ${month}월 ${day}일`;
+  };
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const currentDateObj = new Date(currentDate);
+  currentDateObj.setHours(0, 0, 0, 0);
+
+  const isToday = currentDateObj.getTime() === today.getTime();
+
+  const handlePrevDate = () => {
+    const date = new Date(currentDate);
+    date.setDate(date.getDate() - 1);
+    onDateChange({ target: { value: date.toISOString().split('T')[0] } });
+  };
+
+  const handleNextDate = () => {
+    const date = new Date(currentDate);
+    date.setDate(date.getDate() + 1);
+
+    const nextDate = new Date(date);
+    nextDate.setHours(0, 0, 0, 0);
+
+    if (nextDate.getTime() <= today.getTime()) {
+      onDateChange({ target: { value: date.toISOString().split('T')[0] } });
+    }
+  };
+
+  const handleDateChange = (e) => {
+    const selectedDate = new Date(e.target.value);
+    selectedDate.setHours(0, 0, 0, 0);
+
+    if (selectedDate.getTime() <= today.getTime()) {
+      onDateChange(e);
+    }
+  };
+
+  return (
+      <div className="bg-white rounded-xl shadow-sm p-3 mb-4">
+        <div className="flex items-center justify-center gap-2">
+          <button
+              onClick={handlePrevDate}
+              className="p-1 rounded-full hover:bg-gray-100 transition-colors"
+              aria-label="이전 날짜"
+          >
+            <ChevronLeft className="w-5 h-5 text-gray-500"/>
+          </button>
+
+          <div className="flex items-center gap-2">
+          <span className="text-gray-900 font-medium min-w-[150px] text-center">
+            {formatDate(currentDate)}
+          </span>
+            <input
+                type="date"
+                className="sr-only"
+                value={currentDate}
+                onChange={handleDateChange}
+                max={new Date().toISOString().split('T')[0]}
+            />
+          </div>
+
+          {!isToday && (
+              <button
+                  onClick={handleNextDate}
+                  className="p-1 rounded-full hover:bg-gray-100 transition-colors"
+                  aria-label="다음 날짜"
+              >
+                <ChevronRight className="w-5 h-5 text-gray-500"/>
+              </button>
+          )}
+          {isToday && <div className="w-7"/>}
+        </div>
+      </div>
+  );
+};
+
+export default DateNavigation;


### PR DESCRIPTION
## 관련 이슈
- Closes #37 

## 변경 사항
1. 출석부 관리 페이지 API 연동 구현
   - axios 인스턴스를 활용한 API 통신 로직 구현
   - 출석 상태 데이터 백엔드 연동을 위한 enum 변환 처리 추가
   - API 응답 데이터 형식에 맞춰 학생 정보 포맷팅 로직 수정
   - 출석 정보 저장 API 연동 및 에러 처리 구현
   - 불필요한 임시 지연 코드(setTimeout) 제거

2. 출석부 날짜 네비게이션 컴포넌트 추가
   - 이전/다음 날짜로 이동하는 화살표 버튼 구현
   - 오늘 날짜 이후로는 이동할 수 없도록 제한 구현

3. 출석부 상단 섹션 UI/UX 개선
   - 날짜 선택 input을 별도 DateNavigation 컴포넌트로 분리
   - 이전/다음으로 날짜 이동이 가능한 네비게이션 UI 추가
   - 상단 섹션 레이아웃 구조 개선 및 여백 조정
   - '출석부' 텍스트를 '출석률'로 변경하여 통계 정보 명확화

## 스크린샷
|기능|변경 전|변경 후|
|---|---|---|
|날짜 네비게이션 UI|![image](https://github.com/user-attachments/assets/42414b47-8da4-4fe8-9a84-3af42acead3b)|![image](https://github.com/user-attachments/assets/317dace7-d831-4672-86a4-694b64e94239)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- API 연동 시 출석 상태값은 enum으로 변환하여 처리하도록 구현했습니다.
- 날짜 이동은 오늘 날짜를 초과하지 않도록 제한했습니다.
- 컴포넌트 분리를 통해 코드 재사용성과 유지보수성을 개선했습니다.

## 추후 업무
- [ ] 와이어프레임 기반 UI 구현