### PR TITLE
[FEAT] 마이페이지의 프로필 설정 및 강의/수강 이력 조회 기능 구현

### DIFF
--- a/src/components/layout/SimpleLayout.jsx
+++ b/src/components/layout/SimpleLayout.jsx
@@ -6,11 +6,12 @@ import { Outlet } from "react-router-dom";
  */
 const SimpleLayout = () => {
   return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-gray-50 pt-20">
         <TopBar/>
-        <Outlet/>
+        <div className="max-w-7xl mx-auto px-4">
+          <Outlet/>
+        </div>
       </div>
   );
 };
-
 export default SimpleLayout;

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { signOut } from 'aws-amplify/auth';
+import { signOut, fetchUserAttributes } from 'aws-amplify/auth';
 import Logo from '../../assets/epariLogo.jpg';
 
 /**
@@ -10,6 +10,22 @@ import Logo from '../../assets/epariLogo.jpg';
 const TopBar = () => {
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [userName, setUserName] = useState('');
+  const [profileImage, setProfileImage] = useState(null);
+
+  useEffect(() => {
+    const getUserInfo = async () => {
+      try {
+        const userAttributes = await fetchUserAttributes();
+        setUserName(userAttributes.name);
+        setProfileImage(userAttributes['custom:profile_image']);
+      } catch (err) {
+        console.error('Error fetching user info:', err);
+      }
+    };
+
+    getUserInfo();
+  }, []);
 
   const handleLogout = async () => {
     try {
@@ -42,11 +58,19 @@ const TopBar = () => {
                 className="w-10 h-10 rounded-full overflow-hidden"
                 onMouseEnter={() => setIsDropdownOpen(true)}
             >
-              <img
-                  src="/api/placeholder/40/40"
-                  alt="프로필"
-                  className="w-full h-full object-cover"
-              />
+              {profileImage ? (
+                  <img
+                      src={profileImage}
+                      alt="프로필"
+                      className="w-full h-full object-cover"
+                  />
+              ) : (
+                  <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-400">
+                <span className="text-lg font-semibold">
+                  {userName ? userName[0] : ''}
+                </span>
+                  </div>
+              )}
             </button>
 
             {/* Dropdown Menu */}

--- a/src/components/mypage/CourseHistory.jsx
+++ b/src/components/mypage/CourseHistory.jsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react';
+import { Clock, MapPin, UserCircle2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import axios from '../../api/axios.js';
+
+/**
+ * 마이페이지의 강의 이력 및 수강 이력을 표시하는 컴포넌트
+ */
+const CourseHistory = () => {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isInstructor, setIsInstructor] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      try {
+        const response = await axios.get('/api/courses/usercourses');
+        setCourses(response.data);
+
+        // 토큰에서 역할 확인
+        const token = localStorage.getItem('token');
+        const payload = token.split('.')[1];
+        const decodedPayload = JSON.parse(atob(payload));
+        setIsInstructor(decodedPayload['cognito:groups']?.includes('INSTRUCTOR') || false);
+
+      } catch (err) {
+        setError('강의 이력을 불러오는데 실패했습니다.');
+        console.error('Error:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCourses();
+  }, []);
+
+  if (loading) {
+    return (
+        <div className="flex items-center justify-center h-48">
+          <div className="text-xl">강의 이력을 불러오는 중...</div>
+        </div>
+    );
+  }
+
+  if (error) {
+    return (
+        <div className="flex items-center justify-center h-48">
+          <div className="text-xl text-red-500">{error}</div>
+        </div>
+    );
+  }
+
+  return (
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">
+          {isInstructor ? '강의 이력' : '수강 이력'}
+        </h2>
+
+        {courses.length === 0 ? (
+            <div className="text-center text-gray-500 py-8">
+              {isInstructor ? '강의 이력이 없습니다.' : '수강 이력이 없습니다.'}
+            </div>
+        ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {courses.map((course) => (
+                  <div
+                      key={course.id}
+                      className="bg-white rounded-lg shadow-sm overflow-hidden cursor-pointer hover:shadow-md transition-shadow"
+                      onClick={() => navigate(`/courses/${course.id}`)}
+                  >
+                    <div className="h-24 bg-blue-50 relative">
+                      {course.imageUrl ? (
+                          <img
+                              src={course.imageUrl}
+                              alt={course.name}
+                              className="w-full h-full object-cover"
+                              onError={(e) => {
+                                e.target.style.display = 'none';
+                                e.target.parentElement.innerHTML = `
+                        <div class="w-full h-full flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100">
+                          <div class="text-blue-200">
+                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                              <circle cx="12" cy="7" r="4"></circle>
+                            </svg>
+                          </div>
+                        </div>
+                      `;
+                              }}
+                          />
+                      ) : (
+                          <div
+                              className="w-full h-full flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100">
+                            <div className="text-blue-200">
+                              <UserCircle2 size={48}/>
+                            </div>
+                          </div>
+                      )}
+                    </div>
+
+                    <div className="p-4">
+                      <h3 className="font-medium text-gray-900 mb-2 line-clamp-2">
+                        {course.name}
+                      </h3>
+
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-sm text-gray-500">
+                          <Clock size={16}/>
+                          <span>{course.startDate} ~ {course.endDate}</span>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-2 flex-1">
+                            <UserCircle2 size={16} className="text-gray-400"/>
+                            <span className="text-sm font-medium text-gray-700">
+                        {course.instructor?.name || '강사 미정'}
+                      </span>
+                          </div>
+                          {course.classroom && (
+                              <div className="flex items-center gap-1 text-gray-500">
+                                <MapPin size={16}/>
+                                <span className="text-sm">{course.classroom}</span>
+                              </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+              ))}
+            </div>
+        )}
+      </div>
+  );
+};
+
+export default CourseHistory;

--- a/src/components/mypage/CourseHistory.jsx
+++ b/src/components/mypage/CourseHistory.jsx
@@ -19,7 +19,6 @@ const CourseHistory = () => {
         const response = await axios.get('/api/courses/usercourses');
         setCourses(response.data);
 
-        // 토큰에서 역할 확인
         const token = localStorage.getItem('token');
         const payload = token.split('.')[1];
         const decodedPayload = JSON.parse(atob(payload));
@@ -53,7 +52,7 @@ const CourseHistory = () => {
   }
 
   return (
-      <div className="space-y-6">
+      <div className="bg-white rounded-lg px-12 py-8 space-y-6">
         <h2 className="text-2xl font-bold">
           {isInstructor ? '강의 이력' : '수강 이력'}
         </h2>
@@ -115,8 +114,8 @@ const CourseHistory = () => {
                           <div className="flex items-center gap-2 flex-1">
                             <UserCircle2 size={16} className="text-gray-400"/>
                             <span className="text-sm font-medium text-gray-700">
-                        {course.instructor?.name || '강사 미정'}
-                      </span>
+                              {course.instructor?.name || '강사 미정'}
+                            </span>
                           </div>
                           {course.classroom && (
                               <div className="flex items-center gap-1 text-gray-500">

--- a/src/components/mypage/MyPageContent.jsx
+++ b/src/components/mypage/MyPageContent.jsx
@@ -29,9 +29,6 @@ const MyPageContent = () => {
       });
       setLoading(false);
 
-      if (onProfileUpdate) {
-        await onProfileUpdate();
-      }
     } catch (err) {
       console.error('Error fetching user info:', err);
       setLoading(false);

--- a/src/components/mypage/MyPageContent.jsx
+++ b/src/components/mypage/MyPageContent.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';  // useState, useEffect 추가
-import { Calendar, MessageCircle } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';  // getCurrentUser, fetchUserAttributes 도 추가
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
 import UserProfile from "./UserProfile.jsx";
+import CourseHistory from "./CourseHistory.jsx";
 
 /**
  * 마이페이지
@@ -25,9 +25,13 @@ const MyPageContent = () => {
       setUserInfo({
         name: userAttributes.name || currentUser.username,
         email: userAttributes.email,
-        profileImage: userAttributes['custom:profile_image']  // 이 부분은 수정된 채로 두어야 합니다
+        profileImage: userAttributes['custom:profile_image']
       });
       setLoading(false);
+
+      if (onProfileUpdate) {
+        await onProfileUpdate();
+      }
     } catch (err) {
       console.error('Error fetching user info:', err);
       setLoading(false);
@@ -45,97 +49,24 @@ const MyPageContent = () => {
         </div>
     );
   }
-  const courses = [
-    {
-      id: 1,
-      title: 'AWS 클라우드를 활용한 MSA 기반 자바 개발자 양성 과정',
-      period: '2024-07-03 ~ 2025-01-07',
-      company: '윤강사',
-      students: 301
-    },
-    {
-      id: 2,
-      title: '스프링 부트와 리액트를 활용한 풀스택 개발자 과정',
-      period: '2024-08-05 ~ 2025-02-28',
-      company: '김강사',
-      students: 302
-    }
-  ];
-
-  const qna = [
-    {
-      id: 1,
-      date: '2024.10.30',
-      category: 'BACKEND',
-      title: 'AWS 인스턴스 구축 관련 질문',
-      hasAnswer: true
-    },
-    {
-      id: 2,
-      date: '2024.07.10',
-      category: 'BACKEND',
-      title: '프로젝트 소개 화면 관련 질문',
-      hasAnswer: true
-    },
-    {
-      id: 3,
-      date: '2024.07.10',
-      category: 'BACKEND',
-      title: '업데이트 사항 질문',
-      hasAnswer: true
-    }
-  ];
 
   return (
-      <div className="bg-white">
+      <div className="bg-white rounded-lg">
         <div className="bg-white min-h-screen">
           <UserProfile
               userInfo={userInfo}
               setUserInfo={setUserInfo}
-              onProfileUpdate={fetchUserInfo}
+              onProfileUpdate={async () => {
+                await fetchUserInfo();
+                window.location.reload();
+              }}
           />
 
           {/* Main Content */}
           <div className="max-w-7xl mx-auto px-4 py-8">
-            {/* 내 강의 목록 */}
+            {/* 강의 이력 섹션 */}
             <div className="mb-8">
-              <h3 className="text-lg font-bold mb-4">수강 이력</h3>
-              <div className="flex gap-4 overflow-x-auto">
-                {courses.map(course => (
-                    <div key={course.id} className="w-1/3 flex-shrink-0 bg-white rounded-lg shadow-sm border p-4">
-                      <h4 className="font-medium mb-2 line-clamp-2">{course.title}</h4>
-                      <div className="flex flex-col text-sm text-gray-500 gap-2">
-                        <div className="flex items-center gap-1">
-                          <Calendar className="w-4 h-4"/>
-                          <span>{course.period}</span>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <MessageCircle className="w-4 h-4"/>
-                          <span>수강생 {course.students}명</span>
-                        </div>
-                      </div>
-                    </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Q&A 섹션 */}
-            <div>
-              <h3 className="text-lg font-bold mb-4">나의 Q&A</h3>
-              <div className="space-y-2">
-                {qna.map(item => (
-                    <div key={item.id} className="flex items-center justify-between py-2 border-b">
-                      <div className="flex items-center gap-4">
-                        <span className="text-sm text-gray-500">{item.date}</span>
-                        <span className="px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded">
-                      {item.category}
-                    </span>
-                        <span>{item.title}</span>
-                      </div>
-                      <button className="text-sm text-purple-600">답변보기</button>
-                    </div>
-                ))}
-              </div>
+              <CourseHistory/>
             </div>
           </div>
         </div>

--- a/src/components/mypage/MyPageContent.jsx
+++ b/src/components/mypage/MyPageContent.jsx
@@ -1,17 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Calendar, MessageCircle, Lock } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
 
 /**
  * 마이페이지
  */
 const MyPageContent = () => {
+  const navigate = useNavigate();
+  const [userInfo, setUserInfo] = useState({
+    name: "",
+    email: ""
+  });
+  const [loading, setLoading] = useState(true);
 
-  const navigate = useNavigate()
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
 
-  const userInfo = {
-    name: "홍길동",
-    email: "hong@example.com"
+  const fetchUserInfo = async () => {
+    try {
+      // 현재 인증된 사용자 정보와 속성 가져오기
+      const currentUser = await getCurrentUser();
+      const userAttributes = await fetchUserAttributes();
+
+      setUserInfo({
+        name: userAttributes.name || currentUser.username,
+        email: userAttributes.email
+      });
+      setLoading(false);
+    } catch (err) {
+      console.error('Error fetching user info:', err);
+      setLoading(false);
+    }
   };
 
   const courses = [
@@ -55,29 +76,34 @@ const MyPageContent = () => {
     }
   ];
 
+  if (loading) {
+    return (
+        <div className="flex justify-center items-center min-h-screen">
+          <div className="text-gray-500">Loading...</div>
+        </div>
+    );
+  }
+
   return (
       <div className="bg-white">
         {/* Profile Header */}
         <div className="max-w-7xl mx-auto px-4 py-6 border-b">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-6">
-              <div className="relative">
-                <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-gray-400">
-                  <span className="text-2xl">{userInfo.name[0]}</span>
-                </div>
-              </div>
-              <div>
-                <h2 className="text-xl font-semibold">{userInfo.name}</h2>
-                <p className="text-gray-500">{userInfo.email}</p>
+          <div className="flex items-center gap-6">
+            <div className="relative">
+              <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-gray-400">
+                <span className="text-2xl">{userInfo.name[0]}</span>
               </div>
             </div>
-            <button
-                className="flex items-center gap-2 px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600"
-                onClick={() => navigate('/mypage/change-password')}
-            >
-              <Lock size={16}/>
-              비밀번호 변경
-            </button>
+            <div>
+              <h2 className="text-xl font-semibold">{userInfo.name}</h2>
+              <p className="text-gray-500 mt-1 mb-1">{userInfo.email}</p>
+              <button
+                  onClick={() => navigate('/mypage/change-password')}
+                  className="text-sm text-blue-600 hover:underline mt-1"
+              >
+                비밀번호 변경
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/components/mypage/MyPageContent.jsx
+++ b/src/components/mypage/MyPageContent.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { Calendar, MessageCircle, Lock } from 'lucide-react';
+import React, { useState, useEffect } from 'react';  // useState, useEffect 추가
+import { Calendar, MessageCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';  // getCurrentUser, fetchUserAttributes 도 추가
+import UserProfile from "./UserProfile.jsx";
 
 /**
  * 마이페이지
@@ -10,23 +11,21 @@ const MyPageContent = () => {
   const navigate = useNavigate();
   const [userInfo, setUserInfo] = useState({
     name: "",
-    email: ""
+    email: "",
+    profileImage: null
   });
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchUserInfo();
-  }, []);
+  const [loading, setLoading] = useState(true);
 
   const fetchUserInfo = async () => {
     try {
-      // 현재 인증된 사용자 정보와 속성 가져오기
       const currentUser = await getCurrentUser();
       const userAttributes = await fetchUserAttributes();
 
       setUserInfo({
         name: userAttributes.name || currentUser.username,
-        email: userAttributes.email
+        email: userAttributes.email,
+        profileImage: userAttributes['custom:profile_image']  // 이 부분은 수정된 채로 두어야 합니다
       });
       setLoading(false);
     } catch (err) {
@@ -35,6 +34,17 @@ const MyPageContent = () => {
     }
   };
 
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
+
+  if (loading) {
+    return (
+        <div className="flex justify-center items-center min-h-screen">
+          <div className="text-gray-500">Loading...</div>
+        </div>
+    );
+  }
   const courses = [
     {
       id: 1,
@@ -76,77 +86,56 @@ const MyPageContent = () => {
     }
   ];
 
-  if (loading) {
-    return (
-        <div className="flex justify-center items-center min-h-screen">
-          <div className="text-gray-500">Loading...</div>
-        </div>
-    );
-  }
-
   return (
       <div className="bg-white">
-        {/* Profile Header */}
-        <div className="max-w-7xl mx-auto px-4 py-6 border-b">
-          <div className="flex items-center gap-6">
-            <div className="relative">
-              <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-gray-400">
-                <span className="text-2xl">{userInfo.name[0]}</span>
+        <div className="bg-white min-h-screen">
+          <UserProfile
+              userInfo={userInfo}
+              setUserInfo={setUserInfo}
+              onProfileUpdate={fetchUserInfo}
+          />
+
+          {/* Main Content */}
+          <div className="max-w-7xl mx-auto px-4 py-8">
+            {/* 내 강의 목록 */}
+            <div className="mb-8">
+              <h3 className="text-lg font-bold mb-4">수강 이력</h3>
+              <div className="flex gap-4 overflow-x-auto">
+                {courses.map(course => (
+                    <div key={course.id} className="w-1/3 flex-shrink-0 bg-white rounded-lg shadow-sm border p-4">
+                      <h4 className="font-medium mb-2 line-clamp-2">{course.title}</h4>
+                      <div className="flex flex-col text-sm text-gray-500 gap-2">
+                        <div className="flex items-center gap-1">
+                          <Calendar className="w-4 h-4"/>
+                          <span>{course.period}</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <MessageCircle className="w-4 h-4"/>
+                          <span>수강생 {course.students}명</span>
+                        </div>
+                      </div>
+                    </div>
+                ))}
               </div>
             </div>
+
+            {/* Q&A 섹션 */}
             <div>
-              <h2 className="text-xl font-semibold">{userInfo.name}</h2>
-              <p className="text-gray-500 mt-1 mb-1">{userInfo.email}</p>
-              <button
-                  onClick={() => navigate('/mypage/change-password')}
-                  className="text-sm text-blue-600 hover:underline mt-1"
-              >
-                비밀번호 변경
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Main Content */}
-        <div className="max-w-7xl mx-auto px-4 py-8">
-          {/* 내 강의 목록 */}
-          <div className="mb-8">
-            <h3 className="text-lg font-bold mb-4">수강 이력</h3>
-            <div className="flex gap-4 overflow-x-auto">
-              {courses.map(course => (
-                  <div key={course.id} className="w-1/3 flex-shrink-0 bg-white rounded-lg shadow-sm border p-4">
-                    <h4 className="font-medium mb-2 line-clamp-2">{course.title}</h4>
-                    <div className="flex flex-col text-sm text-gray-500 gap-2">
-                      <div className="flex items-center gap-1">
-                        <Calendar className="w-4 h-4"/>
-                        <span>{course.period}</span>
+              <h3 className="text-lg font-bold mb-4">나의 Q&A</h3>
+              <div className="space-y-2">
+                {qna.map(item => (
+                    <div key={item.id} className="flex items-center justify-between py-2 border-b">
+                      <div className="flex items-center gap-4">
+                        <span className="text-sm text-gray-500">{item.date}</span>
+                        <span className="px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded">
+                      {item.category}
+                    </span>
+                        <span>{item.title}</span>
                       </div>
-                      <div className="flex items-center gap-1">
-                        <MessageCircle className="w-4 h-4"/>
-                        <span>수강생 {course.students}명</span>
-                      </div>
+                      <button className="text-sm text-purple-600">답변보기</button>
                     </div>
-                  </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Q&A 섹션 */}
-          <div>
-            <h3 className="text-lg font-bold mb-4">나의 Q&A</h3>
-            <div className="space-y-2">
-              {qna.map(item => (
-                  <div key={item.id} className="flex items-center justify-between py-2 border-b">
-                    <div className="flex items-center gap-4">
-                      <span className="text-sm text-gray-500">{item.date}</span>
-                      <span className="px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded">
-                    {item.category}
-                  </span>
-                      <span>{item.title}</span>
-                    </div>
-                    <button className="text-sm text-purple-600">답변보기</button>
-                  </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/mypage/UserProfile.jsx
+++ b/src/components/mypage/UserProfile.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Camera, Trash2, Lock } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import axios from '../../api/axios.js';
 
@@ -49,6 +48,8 @@ const UserProfile = ({ userInfo, setUserInfo, onProfileUpdate }) => {
   };
 
   const handleImageDelete = async () => {
+    if (!userInfo.profileImage) return;
+
     try {
       await axios.delete('/api/user/mypage/profile/image');
 
@@ -66,17 +67,16 @@ const UserProfile = ({ userInfo, setUserInfo, onProfileUpdate }) => {
   };
 
   return (
-      <div className="w-full bg-white">
+      <div className="w-full bg-white rounded-lg px-12">
         {/* Page Title */}
         <div className="max-w-7xl mx-auto px-8 pt-8 pb-6">
-          <h1 className="text-2xl font-bold text-gray-900">마이페이지</h1>
         </div>
 
         {/* Profile Section */}
-        <div className="max-w-7xl mx-auto px-8 pb-8 border-b">
-          <div className="flex items-start gap-8">
+        <div className="max-w-7xl mx-auto px-8 pb-12 border-b">
+          <div className="flex items-start gap-12">
             {/* Profile Image Section */}
-            <div className="space-y-4">
+            <div className="space-y-6">
               <div className="w-32 h-32 rounded-full bg-gray-100 overflow-hidden ring-2 ring-offset-2 ring-gray-200">
                 {userInfo.profileImage ? (
                     <img
@@ -92,8 +92,8 @@ const UserProfile = ({ userInfo, setUserInfo, onProfileUpdate }) => {
               </div>
 
               {/* Image Buttons */}
-              <div className="flex gap-2">
-                <label className="flex-1">
+              <div className="flex gap-4">
+                <label>
                   <input
                       type="file"
                       accept="image/*"
@@ -101,38 +101,34 @@ const UserProfile = ({ userInfo, setUserInfo, onProfileUpdate }) => {
                       onChange={handleImageUpload}
                       disabled={uploading}
                   />
-                  <div
-                      className="flex items-center justify-center px-4 py-2 border border-gray-300 rounded-md text-sm text-gray-600 bg-white hover:bg-gray-50 cursor-pointer gap-2">
-                    <Camera className="h-4 w-4"/>
-                    <span>이미지 변경</span>
-                  </div>
+                  <span className="text-sm text-gray-600 hover:underline cursor-pointer">
+                    이미지 변경
+                  </span>
                 </label>
 
-                {userInfo.profileImage && (
-                    <button
-                        onClick={handleImageDelete}
-                        className="px-3 py-2 border border-gray-300 rounded-md text-red-600 hover:text-red-700 hover:bg-red-50"
-                    >
-                      <Trash2 className="h-4 w-4"/>
-                    </button>
-                )}
+                <button
+                    onClick={handleImageDelete}
+                    disabled={!userInfo.profileImage}
+                    className={`text-sm ${userInfo.profileImage ? 'text-rose-500 hover:underline' : 'text-gray-400 cursor-not-allowed'}`}
+                >
+                  삭제
+                </button>
               </div>
             </div>
 
             {/* User Info Section */}
-            <div className="flex-1 space-y-4 pt-2">
+            <div className="flex-1 space-y-6 pt-2">
               <div>
-                <h2 className="text-2xl font-semibold text-gray-900">{userInfo.name}</h2>
-                <p className="text-gray-500 mt-1">{userInfo.email}</p>
+                <h2 className="text-xl font-semibold text-gray-900">{userInfo.name}</h2>
+                <p className="text-lg text-gray-500 mt-2">{userInfo.email}</p>
               </div>
 
               {/* Security Section */}
               <div className="pt-2">
                 <button
                     onClick={() => navigate('/mypage/change-password')}
-                    className="flex items-center text-blue-600 hover:text-blue-800 hover:underline"
+                    className="text-sm text-blue-600 hover:text-blue-800 underline"
                 >
-                  <Lock className="mr-2 h-4 w-4"/>
                   비밀번호 변경
                 </button>
               </div>

--- a/src/components/mypage/UserProfile.jsx
+++ b/src/components/mypage/UserProfile.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { Camera, Trash2, Lock } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import axios from '../../api/axios.js';
+
+const UserProfile = ({ userInfo, setUserInfo, onProfileUpdate }) => {
+  const [uploading, setUploading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleImageUpload = async (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const validTypes = ['image/jpeg', 'image/png', 'image/gif'];
+    if (!validTypes.includes(file.type)) {
+      alert('JPG, PNG, GIF 형식의 이미지만 업로드 가능합니다.');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      alert('파일 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+
+    try {
+      setUploading(true);
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const response = await axios.post('/api/user/mypage/profile/image', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      setUserInfo(prev => ({
+        ...prev,
+        profileImage: response.data
+      }));
+
+      await onProfileUpdate();
+
+    } catch (error) {
+      console.error('Profile image upload failed:', error);
+      alert('프로필 이미지 업로드에 실패했습니다.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleImageDelete = async () => {
+    try {
+      await axios.delete('/api/user/mypage/profile/image');
+
+      setUserInfo(prev => ({
+        ...prev,
+        profileImage: null
+      }));
+
+      await onProfileUpdate();
+
+    } catch (error) {
+      console.error('Profile image deletion failed:', error);
+      alert('프로필 이미지 삭제에 실패했습니다.');
+    }
+  };
+
+  return (
+      <div className="w-full bg-white">
+        {/* Page Title */}
+        <div className="max-w-7xl mx-auto px-8 pt-8 pb-6">
+          <h1 className="text-2xl font-bold text-gray-900">마이페이지</h1>
+        </div>
+
+        {/* Profile Section */}
+        <div className="max-w-7xl mx-auto px-8 pb-8 border-b">
+          <div className="flex items-start gap-8">
+            {/* Profile Image Section */}
+            <div className="space-y-4">
+              <div className="w-32 h-32 rounded-full bg-gray-100 overflow-hidden ring-2 ring-offset-2 ring-gray-200">
+                {userInfo.profileImage ? (
+                    <img
+                        src={userInfo.profileImage}
+                        alt="Profile"
+                        className="w-full h-full object-cover"
+                    />
+                ) : (
+                    <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-400">
+                      <span className="text-4xl font-semibold">{userInfo.name[0]}</span>
+                    </div>
+                )}
+              </div>
+
+              {/* Image Buttons */}
+              <div className="flex gap-2">
+                <label className="flex-1">
+                  <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleImageUpload}
+                      disabled={uploading}
+                  />
+                  <div
+                      className="flex items-center justify-center px-4 py-2 border border-gray-300 rounded-md text-sm text-gray-600 bg-white hover:bg-gray-50 cursor-pointer gap-2">
+                    <Camera className="h-4 w-4"/>
+                    <span>이미지 변경</span>
+                  </div>
+                </label>
+
+                {userInfo.profileImage && (
+                    <button
+                        onClick={handleImageDelete}
+                        className="px-3 py-2 border border-gray-300 rounded-md text-red-600 hover:text-red-700 hover:bg-red-50"
+                    >
+                      <Trash2 className="h-4 w-4"/>
+                    </button>
+                )}
+              </div>
+            </div>
+
+            {/* User Info Section */}
+            <div className="flex-1 space-y-4 pt-2">
+              <div>
+                <h2 className="text-2xl font-semibold text-gray-900">{userInfo.name}</h2>
+                <p className="text-gray-500 mt-1">{userInfo.email}</p>
+              </div>
+
+              {/* Security Section */}
+              <div className="pt-2">
+                <button
+                    onClick={() => navigate('/mypage/change-password')}
+                    className="flex items-center text-blue-600 hover:text-blue-800 hover:underline"
+                >
+                  <Lock className="mr-2 h-4 w-4"/>
+                  비밀번호 변경
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  );
+};
+
+export default UserProfile;

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -3,7 +3,8 @@ import MyPageContent from "../../components/mypage/MyPageContent.jsx";
 
 const MyPage = () => {
   return (
-      <div className="min-h-screen bg-gray-50 pt-28">
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-10">마이페이지</h1>
         <MyPageContent/>
       </div>
   );


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #89 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요. -->
1. **사용자 프로필 정보 표시 및 관리**
   - 사용자 이름과 이메일 정보 표시
   - 프로필 이미지를 업로드/삭제할 수 있는 UI와 기능 구현
   - AWS Amplify Auth를 통한 사용자 정보 불러오기

2. **강의 및 수강 이력 섹션 구현**
   - 강사/학생 역할에 따라 강의 이력 또는 수강 이력 표시
   - 강의 데이터 로딩 및 에러 상태 관리 로직 추가
   - 강의 카드에 이미지, 이름, 일정 등 세부 정보 표시

3. **UI/UX 및 코드 구조 개선**
   - 마이페이지 레이아웃 중앙 정렬 및 여백 추가
   - 페이지 제목 추가
   - 강의 이력 로직을 `CourseHistory` 컴포넌트로 분리
   - 불필요한 Q&A 섹션 및 관련 코드 삭제

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->
|기능|변경 전|변경 후 |
|---|---|---|
|마이페이지|![마이페이지 비포](https://github.com/user-attachments/assets/4cfa1bc1-155f-4409-b38c-c24d5ca298c8)|![프로필사진 변경](https://github.com/user-attachments/assets/d53e7544-343d-4340-ade0-04faa641ee39)|

|기능|스크린샷|
|---|---|
|강사 마이페이지|![강사 마이페이지](https://github.com/user-attachments/assets/2fd3bae7-0fa0-40f7-8366-cddec0c2c967)|
|학생 마이페이지|![학생 마이페이지](https://github.com/user-attachments/assets/b69fc765-9e98-4c54-a974-f4d9777cf02c)|
|프로필 사진 설정|![프로필사진 변경](https://github.com/user-attachments/assets/8b6e29ff-9425-45e3-96ca-1102c651d766)|
|프로필 사진 변경|![프로필사진 변경2](https://github.com/user-attachments/assets/11896371-71b7-4333-a364-82bf07077421)|

## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [ ] 코드 컨벤션을 준수하였습니까?
- [ ] 모든 테스트를 통과하였습니까?
- [ ] 관련 문서를 업데이트하였습니까?

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ] Google 로그인
