### PR TITLE
[FEAT] quill 라이브러리에서 복붙한 이미지가 s3에 저장되도록 기능 구현

### DIFF
--- a/src/components/course/dashboard/CourseListContent.jsx
+++ b/src/components/course/dashboard/CourseListContent.jsx
@@ -36,7 +36,7 @@ const getIsInstructorFromToken = () => {
 
 const CourseListContent = () => {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState('notice');
+  const [activeTab, setActiveTab] = useState('courseNotice');
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);

--- a/src/components/course/detail/CourseDetailContent.jsx
+++ b/src/components/course/detail/CourseDetailContent.jsx
@@ -58,14 +58,15 @@ const CourseDetailContent = () => {
   useEffect(() => {
     const fetchNotices = async () => {
       try {
-        const response = await NoticeApi.getGlobalNotices();
+        const response = await NoticeApi.getCourseNotices(courseId);  // 강의 공지사항을 불러오도록 수정
         const formattedNotices = response
-            .slice(0, 5) // 최대 5개까지만 표시
+            .slice(0, 5)
             .map(notice => ({
               id: notice.id,
               title: notice.title,
               writer: notice.instructorName,
-              date: new Date(notice.createdAt).toLocaleDateString()
+              date: new Date(notice.createdAt).toLocaleDateString(),
+              views: notice.viewCount
             }));
         setNotices(formattedNotices);
       } catch (error) {
@@ -73,10 +74,9 @@ const CourseDetailContent = () => {
       }
     };
 
-    if (activeTab === 'notice') {
-      fetchNotices();
-    }
-  }, [activeTab]);
+    fetchNotices();  // 조건문 없이 바로 실행
+  }, [courseId]);  // activeTab 대신 courseId를 dependency로 변경
+
 
   useEffect(() => {
     const fetchCourseDetails = async () => {
@@ -114,7 +114,7 @@ const CourseDetailContent = () => {
   const handleNavigate = (path) => {
     switch (path) {
       case 'notice':
-        navigate(`/notices`);
+        navigate(`/courses/${courseId}/notices`);
         break;
       case 'qna':
         navigate(`/courses/${courseId}/qna`);
@@ -174,6 +174,7 @@ const CourseDetailContent = () => {
               notices={notices}
               qnas={qnas}
               onNavigate={handleNavigate}
+              courseId={courseId}
           />
         </div>
       </main>

--- a/src/components/course/detail/NoticeQnaSection.jsx
+++ b/src/components/course/detail/NoticeQnaSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * 강의 공지사항/Q&A 섹션 컴포넌트
@@ -7,10 +8,17 @@ import React from 'react';
  * - 전체보기 기능을 통해 상세 페이지로 이동 가능
  */
 
-const NoticeQnaSection = ({ activeTab, setActiveTab, notices, qnas, onNavigate }) => {
+const NoticeQnaSection = ({ activeTab, setActiveTab, notices, qnas, onNavigate, courseId }) => {
+  const navigate = useNavigate();
+
   const handleViewAll = () => {
-    onNavigate(activeTab); // 'notice' 또는 'qna'로 전달
+    onNavigate(activeTab);
   };
+
+  const handleNoticeClick = (noticeId) => {
+    navigate(`/courses/${courseId}/notices/${noticeId}`);
+  };
+
   return (
       <div className="bg-white rounded-lg p-6 mb-6">
         <div className="flex gap-6 mb-6 border-b">
@@ -60,7 +68,11 @@ const NoticeQnaSection = ({ activeTab, setActiveTab, notices, qnas, onNavigate }
           <tbody>
           {activeTab === 'notice'
               ? notices.map(notice => (
-                  <tr key={notice.id} className="border-b hover:bg-gray-50">
+                  <tr
+                      key={notice.id}
+                      className="border-b hover:bg-gray-50 cursor-pointer"
+                      onClick={() => handleNoticeClick(notice.id)}
+                  >
                     <td className="py-2 text-sm">{notice.id}</td>
                     <td className="py-2 text-sm">{notice.title}</td>
                     <td className="py-2 text-sm">{notice.writer}</td>


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #140 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
- 복붙한 이미지도 저장되도록 로직 구현
- 강의 페이지에서 공지사항이 전체 공지사항으로 나오는 부분을 강의 공지사항으로 변경

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->

|기능|스크린샷|
|---|---|
|복붙 이미지 s3에 저장|![image](https://github.com/user-attachments/assets/a0574202-2bbb-4b53-9b14-b517b0c83bb1)|

|기능|스크린샷|
|---|---|
|강의 공지사항 나오도록 변경|![image](https://github.com/user-attachments/assets/786b0e6d-ab67-415b-9de7-300e676bcc5d)|




## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [ ] 관련 문서를 업데이트하였습니까?

## 공유사항

<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->


## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ] 백엔드 페이지네이션
